### PR TITLE
Node ES6 modules example uses abbreviated package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ var config = {
 ```javascript
 import postcss from 'postcss';
 import syntax from 'postcss-scss';
-import stripInlineComments from 'strip-inline-comments';
+import stripInlineComments from 'postcss-strip-inline-comments';
 
 let css = fs.readFileSync('style.css', 'utf8');
 


### PR DESCRIPTION
This is either a typo, or some kind of ES6 magic that I don't understand
